### PR TITLE
LDAP tweaks

### DIFF
--- a/ckanext/lcrnz/templates/user/login.html
+++ b/ckanext/lcrnz/templates/user/login.html
@@ -5,7 +5,7 @@
   <section class="module lcnz-ldap-login">
     <div class="module-content">
       <h1 class="page-heading">{{ _('Landcare Staff Registration') }}</h1>
-        Landcare staff, if this is your first login, {% link_for 'click here', controller='ckanext.lcrnz.controllers.user:UserController', action='ldap_login' %} to register with your existing network username and password
+        Landcare staff, if this is your <b>first login</b>, {% link_for 'click here', controller='ckanext.lcrnz.controllers.user:UserController', action='ldap_login' %} to register with your existing network username and password, otherwise login below.
       <div class="form-actions"></div>
     </div>
   </section>

--- a/ckanext/lcrnz/templates/user/login.html
+++ b/ckanext/lcrnz/templates/user/login.html
@@ -4,15 +4,15 @@
 
   <section class="module lcnz-ldap-login">
     <div class="module-content">
-      <h1 class="page-heading">{{ _('Landcare Staff Login') }}</h1>
-        Landcare Research staff {% link_for 'click here', controller='ckanext.lcrnz.controllers.user:UserController', action='ldap_login' %} to login with your existing network username and password
+      <h1 class="page-heading">{{ _('Landcare Staff Registration') }}</h1>
+        Landcare staff, if this is your first login, {% link_for 'click here', controller='ckanext.lcrnz.controllers.user:UserController', action='ldap_login' %} to register with your existing network username and password
       <div class="form-actions"></div>
     </div>
   </section>
 
   <section class="module lcnz-login">
     <div class="module-content">
-      <h1 class="page-heading">{{ _('Login (Non Landcare Research Users)') }}</h1>
+      <h1 class="page-heading">{{ _('Login (Registered Users)') }}</h1>
         {% snippet "user/snippets/login_form.html", action=c.login_handler, error_summary=error_summary %}
     </div>
   </section>

--- a/ckanext/lcrnz/templates/user/login_ldap.html
+++ b/ckanext/lcrnz/templates/user/login_ldap.html
@@ -23,9 +23,10 @@
       <h2 class="module-heading">{{ _('Landcare Research users') }}</h2>
       <div class="module-content">
         <p>
-        This form allows Landcare Research users to login
-        using their existing credentials. If you are not
-        a Landcare Research user please login on the
+        This form allows Landcare Research users to register
+        and login using their existing network credentials. 
+        If you have already registered, or are not a
+        Landcare Research user please login on the 
         <a href="/user/login">main login page</a>.
         </p>
       </div>


### PR DESCRIPTION
Tweaks to the LDAP login screens for Landcare staff to make clearer need to only use LDAP login the first time (which sets default permissions), and after that just login as a normal CKAN user.
